### PR TITLE
#20 Groundwork: design-time data binding

### DIFF
--- a/xamarin-forms/ProjectFocus.ViewModel.Mock/MainViewModel.cs
+++ b/xamarin-forms/ProjectFocus.ViewModel.Mock/MainViewModel.cs
@@ -1,0 +1,10 @@
+﻿using System.Windows.Input;
+using ProjectFocus.Interface;
+
+namespace ProjectFocus.ViewModel.Mock
+{
+    public class MainViewModel : IMainViewModel
+    {
+        public ICommand ProblemCommand { get; }
+    }
+}

--- a/xamarin-forms/ProjectFocus.ViewModel.Mock/ProblemViewModel.cs
+++ b/xamarin-forms/ProjectFocus.ViewModel.Mock/ProblemViewModel.cs
@@ -1,0 +1,9 @@
+﻿using ProjectFocus.Interface;
+
+namespace ProjectFocus.ViewModel.Mock
+{
+    public class ProblemViewModel : IProblemViewModel
+    {
+        public string Text { get; set; } = "Test Problem View Model";
+    }
+}

--- a/xamarin-forms/ProjectFocus.ViewModel.Mock/ProjectFocus.ViewModel.Mock.csproj
+++ b/xamarin-forms/ProjectFocus.ViewModel.Mock/ProjectFocus.ViewModel.Mock.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ProjectFocus.Interface\ProjectFocus.Interface.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/xamarin-forms/ProjectFocus.sln
+++ b/xamarin-forms/ProjectFocus.sln
@@ -19,6 +19,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProjectFocus.Service", "Pro
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProjectFocus.ViewModel", "ProjectFocus.ViewModel\ProjectFocus.ViewModel.csproj", "{C8A380B3-A324-439F-BC55-6F9FA88147A1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectFocus.ViewModel.Mock", "ProjectFocus.ViewModel.Mock\ProjectFocus.ViewModel.Mock.csproj", "{E34B6330-42EF-4724-8933-B25B84D892E1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Ad-Hoc|Any CPU = Ad-Hoc|Any CPU
@@ -451,6 +453,54 @@ Global
 		{C8A380B3-A324-439F-BC55-6F9FA88147A1}.Release|x64.Build.0 = Release|Any CPU
 		{C8A380B3-A324-439F-BC55-6F9FA88147A1}.Release|x86.ActiveCfg = Release|Any CPU
 		{C8A380B3-A324-439F-BC55-6F9FA88147A1}.Release|x86.Build.0 = Release|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Ad-Hoc|Any CPU.ActiveCfg = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Ad-Hoc|Any CPU.Build.0 = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Ad-Hoc|ARM.ActiveCfg = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Ad-Hoc|ARM.Build.0 = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Ad-Hoc|iPhone.ActiveCfg = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Ad-Hoc|iPhone.Build.0 = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Ad-Hoc|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Ad-Hoc|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Ad-Hoc|x64.ActiveCfg = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Ad-Hoc|x64.Build.0 = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Ad-Hoc|x86.ActiveCfg = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Ad-Hoc|x86.Build.0 = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.AppStore|Any CPU.ActiveCfg = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.AppStore|Any CPU.Build.0 = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.AppStore|ARM.ActiveCfg = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.AppStore|ARM.Build.0 = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.AppStore|iPhone.ActiveCfg = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.AppStore|iPhone.Build.0 = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.AppStore|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.AppStore|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.AppStore|x64.ActiveCfg = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.AppStore|x64.Build.0 = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.AppStore|x86.ActiveCfg = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.AppStore|x86.Build.0 = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Debug|ARM.Build.0 = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Debug|x64.Build.0 = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Debug|x86.Build.0 = Debug|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Release|ARM.ActiveCfg = Release|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Release|ARM.Build.0 = Release|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Release|iPhone.Build.0 = Release|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Release|x64.ActiveCfg = Release|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Release|x64.Build.0 = Release|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Release|x86.ActiveCfg = Release|Any CPU
+		{E34B6330-42EF-4724-8933-B25B84D892E1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/xamarin-forms/ProjectFocus/App.xaml.cs
+++ b/xamarin-forms/ProjectFocus/App.xaml.cs
@@ -18,6 +18,9 @@ namespace ProjectFocus
             // [Exercise][ToDo] Find a way to solve this in pure XAML.
             var navigationPage = new NavigationPage();
             MainPage = navigationPage;
+
+            if (DesignMode.IsDesignModeEnabled) return;
+
             new AppComposer().Compose(navigationPage);
         }
 

--- a/xamarin-forms/ProjectFocus/DesignBindingBehavior.cs
+++ b/xamarin-forms/ProjectFocus/DesignBindingBehavior.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using Xamarin.Forms;
+
+namespace ProjectFocus
+{
+    /// <summary>
+    /// A design-time-only behavior that binds its
+    /// associated ContentPage to an instance the given type.
+    /// </summary>
+    public class DesignBindingBehavior : Behavior<ContentPage>
+    {
+        public static readonly BindableProperty ObjectTypeProperty =
+            BindableProperty.CreateAttached("ObjectType", typeof(Type), typeof(DesignBindingBehavior), null, propertyChanged: OnObjectTypeChanged);
+
+        public static Type GetObjectType(BindableObject view)
+        {
+            return (Type)view.GetValue(ObjectTypeProperty);
+        }
+
+        public static void SetObjectType(BindableObject view, Type value)
+        {
+            view.SetValue(ObjectTypeProperty, value);
+        }
+
+        public ContentPage AssociatedObject { get; private set; }
+
+        protected override void OnAttachedTo(ContentPage bindable)
+        {
+            base.OnAttachedTo(bindable);
+            AssociatedObject = bindable;
+
+            if (DesignMode.IsDesignModeEnabled)
+            {
+                InstantiateAndBind(GetObjectType(this), bindable);
+            }
+        }
+
+        protected override void OnDetachingFrom(ContentPage bindable)
+        {
+            base.OnDetachingFrom(bindable);
+            AssociatedObject = null;
+        }
+
+        private static void OnObjectTypeChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            if (DesignMode.IsDesignModeEnabled)
+            {
+                var objectType = newValue as Type;
+                var behavior = (DesignBindingBehavior)bindable;
+                InstantiateAndBind(objectType, behavior.AssociatedObject);
+            }
+        }
+
+        private static void InstantiateAndBind(Type contextType, ContentPage bindable)
+        {
+            if (bindable == null || contextType == null) return;
+
+            var contextInstance = Activator.CreateInstance(contextType);
+            bindable.BindingContext = contextInstance;
+        }
+    }
+}

--- a/xamarin-forms/ProjectFocus/ProblemPage.xaml
+++ b/xamarin-forms/ProjectFocus/ProblemPage.xaml
@@ -1,8 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:ProjectFocus"
+             xmlns:design="clr-namespace:ProjectFocus.ViewModel.Mock;assembly=ProjectFocus.ViewModel.Mock"
              x:Class="ProjectFocus.ProblemPage"
              Title="Problem">
+    <ContentPage.Behaviors>
+      <local:DesignBindingBehavior ObjectType="{x:Type design:ProblemViewModel}"/>
+    </ContentPage.Behaviors>
     <ContentPage.Content>
         <StackLayout>
             <Label Text="{Binding Text}"

--- a/xamarin-forms/ProjectFocus/ProjectFocus.csproj
+++ b/xamarin-forms/ProjectFocus/ProjectFocus.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ProjectFocus.Service\ProjectFocus.Service.csproj" />
+    <ProjectReference Include="..\ProjectFocus.ViewModel.Mock\ProjectFocus.ViewModel.Mock.csproj" />
     <ProjectReference Include="..\ProjectFocus.ViewModel\ProjectFocus.ViewModel.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR introduces the support for previewing pages with design-time-only mock view models. For such view models a separate project is created so that they be safely separated from views and real view models.

#20 